### PR TITLE
Allow viewing spawn point

### DIFF
--- a/gfx.cpp
+++ b/gfx.cpp
@@ -363,7 +363,8 @@ void Gfx::loadMenus()
 	hiddenMenu.addItem(MenuItem(48, 7, "AI TRACES", HiddenMenu::AiTraces));
 	hiddenMenu.addItem(MenuItem(48, 7, "PALETTE", HiddenMenu::PaletteSelect));
 	hiddenMenu.addItem(MenuItem(48, 7, "BOT WEAPONS", HiddenMenu::SelectBotWeapons));
-	
+	hiddenMenu.addItem(MenuItem(48, 7, "SEE SPAWN POINT", HiddenMenu::AllowViewingSpawnPoint));
+
 	playerMenu.addItem(MenuItem(3, 7, "PROFILE LOADED", PlayerMenu::PlLoadedProfile));
 	playerMenu.addItem(MenuItem(3, 7, "SAVE PROFILE", PlayerMenu::PlSaveProfile));
 	playerMenu.addItem(MenuItem(3, 7, "SAVE PROFILE AS...", PlayerMenu::PlSaveProfileAs));

--- a/menu/hiddenMenu.cpp
+++ b/menu/hiddenMenu.cpp
@@ -78,6 +78,8 @@ ItemBehavior* HiddenMenu::getItemBehavior(Common& common, MenuItem& item)
 			return new BooleanSwitchBehavior(common, gfx.settings->aiTraces);
 		case AiParallels:
 			return new IntegerBehavior(common, gfx.settings->aiParallels, 1, 16);
+		case AllowViewingSpawnPoint:
+			return new BooleanSwitchBehavior(common, gfx.settings->allowViewingSpawnPoint);
 
 		default:
 			return Menu::getItemBehavior(common, item);

--- a/menu/hiddenMenu.hpp
+++ b/menu/hiddenMenu.hpp
@@ -24,7 +24,8 @@ struct HiddenMenu : Menu
 		ScreenSync,
 		SelectBotWeapons,
 		AiTraces,
-		AiParallels
+		AiParallels,
+		AllowViewingSpawnPoint,
 	};
 	
 	HiddenMenu(int x, int y)

--- a/settings.cpp
+++ b/settings.cpp
@@ -31,6 +31,7 @@ Extensions::Extensions()
 , selectBotWeapons(true)
 , aiTraces(false)
 , aiParallels(3)
+, allowViewingSpawnPoint(false)
 {
 }
 

--- a/settings.hpp
+++ b/settings.hpp
@@ -15,7 +15,7 @@
 // It can then easily reset the extensions if they fail to load.
 struct Extensions
 {
-	static int const myVersion = 5;
+	static int const myVersion = 6;
 	static bool const extensions = true;
 
 	Extensions();
@@ -29,12 +29,14 @@ struct Extensions
 	int aiFrames, aiMutations;
 	bool aiTraces;
 	int aiParallels;
-	
+
 	int fullscreenW;
 	int fullscreenH;
 
 	int zoneTimeout;
 	uint32_t selectBotWeapons;
+
+	bool allowViewingSpawnPoint;
 };
 
 struct Rand;
@@ -250,6 +252,9 @@ void archive_liero(Archive ar, Settings& settings, Rand& rand)
 		gvl::enable_when(ar, fileExtensionVersion >= 5)
 			.b(settings.aiTraces, false)
 			.ui16(settings.aiParallels, 3);
+
+		gvl::enable_when(ar, fileExtensionVersion >= 6)
+			.b(settings.allowViewingSpawnPoint, false);
 	}
 	catch(std::runtime_error&)
 	{
@@ -312,6 +317,8 @@ void archive(Archive ar, Settings& settings)
 	gvl::enable_when(ar, fileExtensionVersion >= 4)
 		.ui16(settings.zoneTimeout, 30);
 
+	gvl::enable_when(ar, fileExtensionVersion >= 6)
+		.b(settings.allowViewingSpawnPoint, false);
 	ar.check();
 }
 

--- a/version.hpp
+++ b/version.hpp
@@ -1,7 +1,7 @@
 #ifndef LIERO_VERSION_HPP
 #define LIERO_VERSION_HPP
 
-static int const myGameVersion = 5;
+static int const myGameVersion = 6;
 static int const myReplayVersion = 3;
 
 #endif // LIERO_VERSION_HPP

--- a/viewport.cpp
+++ b/viewport.cpp
@@ -243,7 +243,7 @@ void Viewport::draw(Game& game, Renderer& renderer, bool isReplay)
 			common.font.drawText(renderer.screenBmp, LS(PressFire), rect.center_x() - 30, 76, 0);
 			common.font.drawText(renderer.screenBmp, LS(PressFire), rect.center_x() - 31, 75, 50);
 
-			if (worm.pressed(Worm::Change))
+			if (game.settings->allowViewingSpawnPoint && worm.pressed(Worm::Change))
 			{
 				int tempX = ftoi(worm.x) - 7 + offsX;
 				int tempY = ftoi(worm.y) - 5 + offsY;


### PR DESCRIPTION
The idea behind this is that when the spawn point is near one of the
edges of the map, there was previously no way to see exactly where you
would spawn. This would get problematic if there were spike bombs etc in
the area. It's simply not fun to spawn and then immediately lose a lot
of health with no way of preventing it.

The spawn point is not displayed automatically because when I discussed
this potential change with players they were concerned that the other
player could see where they would spawn. Having this on a button
mitigates that concern. As a bonus, I don't have to figure out a way of
drawing the worm that makes it clear you haven't spawned yet.

This is added as a setting that is disabled by default, as it does affect game balance.
