### PR TITLE
Don't open directories as if they were files

### DIFF
--- a/filesystem.cpp
+++ b/filesystem.cpp
@@ -3,6 +3,7 @@
 #include <stdexcept>
 #include <cassert>
 #include <cctype>
+#include <sys/stat.h>
 
 std::string changeLeaf(std::string const& path, std::string const& newLeaf)
 {
@@ -67,6 +68,11 @@ void toLowerCase(std::string& str)
 
 FILE* tolerantFOpen(std::string const& name, char const* mode)
 {
+	struct stat st;
+	stat(name.c_str(), &st);
+	if (((st.st_mode) & S_IFMT) == S_IFDIR)
+		return 0;
+
 	FILE* f = std::fopen(name.c_str(), mode);
 	if(f)
 		return f;


### PR DESCRIPTION
Fixes crash when selecting a folder in the level selector on Linux.

fopen() is only expected to work on files, and since it's called
tolerantFOpen() it may as well be tolerant to trying to open directories
as if they were files.

Fix tested on Windows and Linux
