### PR TITLE
Single screen replay

### DIFF
--- a/common.cpp
+++ b/common.cpp
@@ -363,9 +363,9 @@ void Common::load(FsNode node)
 				std::size_t dataSize = gvl::read_uint32_le(r);
 
 				s.originalData.resize(dataSize);
-		
-				for (auto& s : s.originalData)
-					s = r.get() - 128;
+
+				for (auto& t : s.originalData)
+					t = r.get() - 128;
 
 				s.sound = sfx_new_sound(dataSize * 2);
 

--- a/common_writer.cpp
+++ b/common_writer.cpp
@@ -96,10 +96,10 @@ void commonSave(Common& common, std::string const& path)
 		gvl::write_uint32_le(w, (uint32_t)s.originalData.size() * 1 * 1); // Data size
 
 		auto curSize = s.originalData.size();
-			
-		for (auto& s : s.originalData)
-			w.put(s + 128);
-			
+
+		for (auto& t : s.originalData)
+			w.put(t + 128);
+
 		while (curSize < roundedSize)
 		{
 			w.put(0); // Padding

--- a/controller/replayController.cpp
+++ b/controller/replayController.cpp
@@ -2,6 +2,7 @@
 
 #include "../game.hpp"
 #include "stats_presenter.hpp"
+#include "../viewport.hpp"
 #include "../sfx.hpp"
 
 ReplayController::ReplayController(
@@ -158,6 +159,10 @@ void ReplayController::changeState(State newState)
 	
 	if(newState == StateGame)
 	{
+		if (game->settings->singleScreenReplay) {
+			game->clearViewports();
+			game->addViewport(new Viewport(gvl::rect(0, 0, 504, 350), game->worms[0]->index, 100, 504, 350));
+		}
 		game->startGame();
 #if !ENABLE_TRACING
 		initialGame.reset(new Game(*game));

--- a/controller/replayController.cpp
+++ b/controller/replayController.cpp
@@ -161,7 +161,9 @@ void ReplayController::changeState(State newState)
 	{
 		if (gfx.settings->singleScreenReplay) {
 			game->clearViewports();
-			game->addViewport(new Viewport(gvl::rect(0, 0, 504, 350), game->worms[0]->index, 100, 504, 350));
+			game->addViewport(new Viewport(gvl::rect(0, 0, 504 + 68, 350), game->worms[0]->index, 0, 504, 350));
+			// TODO: a bit weird to duplicate this, but it's needed to draw health bars etc
+			game->addViewport(new Viewport(gvl::rect(0, 0, 504 + 68, 350), game->worms[1]->index, 316, 504, 350));
 		}
 		game->startGame();
 #if !ENABLE_TRACING

--- a/controller/replayController.cpp
+++ b/controller/replayController.cpp
@@ -161,9 +161,10 @@ void ReplayController::changeState(State newState)
 	{
 		if (gfx.settings->singleScreenReplay) {
 			game->clearViewports();
+			// +68 on x to align the viewport in the middle
 			game->addViewport(new Viewport(gvl::rect(0, 0, 504 + 68, 350), game->worms[0]->index, 0, 504, 350));
 			// TODO: a bit weird to duplicate this, but it's needed to draw health bars etc
-			game->addViewport(new Viewport(gvl::rect(0, 0, 504 + 68, 350), game->worms[1]->index, 316, 504, 350));
+			game->addViewport(new Viewport(gvl::rect(0, 0, 504 + 68, 350), game->worms[1]->index, 538, 504, 350));
 		}
 		game->startGame();
 #if !ENABLE_TRACING

--- a/controller/replayController.cpp
+++ b/controller/replayController.cpp
@@ -159,7 +159,7 @@ void ReplayController::changeState(State newState)
 	
 	if(newState == StateGame)
 	{
-		if (game->settings->singleScreenReplay) {
+		if (gfx.settings->singleScreenReplay) {
 			game->clearViewports();
 			game->addViewport(new Viewport(gvl::rect(0, 0, 504, 350), game->worms[0]->index, 100, 504, 350));
 		}

--- a/controller/replayController.cpp
+++ b/controller/replayController.cpp
@@ -42,11 +42,7 @@ void ReplayController::focus()
 	{
 		try
 		{
-#if 1 // TEMP
-			game = replay->beginPlayback(common, gvl::shared_ptr<SoundPlayer>(new NullSoundPlayer()));
-#else
 			game = replay->beginPlayback(common, gvl::shared_ptr<SoundPlayer>(new DefaultSoundPlayer(*common)));
-#endif
 		}
 		catch(std::runtime_error& e)
 		{

--- a/controller/stats_presenter.cpp
+++ b/controller/stats_presenter.cpp
@@ -35,19 +35,19 @@ struct StatsRenderer
 	, game(game)
 	, stats(stats)
 	, common(common)
+	, paneWidth(renderer.renderResX - 20)
 	{
-		
 	}
 
 	static int const paneX = 10;
-	static int const paneWidth = 320-20;
+	int paneWidth = 300;
 
 	template<typename P>
 	void pane(int n, int leftX, int topY, P const& p)
 	{
-		offsX = n * 320 + leftX;
+		offsX = n * renderer.renderResX + leftX;
 
-		if (offsX >= -320 && offsX < 320)
+		if (offsX >= -renderer.renderResX && offsX < renderer.renderResX)
 		{
 			y = topY;
 			y += 10;
@@ -64,7 +64,7 @@ struct StatsRenderer
 	bool hblock(int height, B const& b)
 	{
 		bool ran = false;
-		if (y < 200
+		if (y < renderer.renderResY
 		 && y + height > 0)
 		{
 			b();
@@ -79,7 +79,7 @@ struct StatsRenderer
 		hblock(20, [this] {
 			for (int i = 0; i < 2; ++i)
 			{
-				int x = 160 + (i == 0 ? -1 : 1) * (160 / 2) + offsX;
+				int x = renderer.renderResX / 2 + (i == 0 ? -1 : 1) * (renderer.renderResX / 4) + offsX;
 				blitImage(renderer.screenBmp, common.wormSpriteObj(2, i == 0 ? 1 : 0, i), x - 8, y);
 
 				cell c(i == 0 ? cell::right : cell::left);
@@ -96,7 +96,7 @@ struct StatsRenderer
 	void drawWorm(int i)
 	{
 		bool visible = hblock(20, [this, i] {
-			int x = 160 + offsX;
+			int x = renderer.renderResX / 2 + offsX;
 			blitImage(renderer.screenBmp, common.wormSpriteObj(2, i == 0 ? 1 : 0, i), x - 8, y);
 
 			cell c(i == 0 ? cell::right : cell::left);
@@ -121,12 +121,12 @@ struct StatsRenderer
 		hblock(11, [this, name, &wormStat] {
 			common.font.drawText(
 				renderer.screenBmp,
-				cell(cell::center).ref() << name, 160 + offsX, y, textColor);
+				cell(cell::center).ref() << name, renderer.renderResX / 2 + offsX, y, textColor);
 
 			for (int i = 0; i < 2; ++i)
 			{
 				cell::placement p = i == 0 ? cell::right : cell::left;
-				int x = 160 + (i == 0 ? -40 : 40) + offsX;
+				int x = renderer.renderResX / 2 + (i == 0 ? -40 : 40) + offsX;
 
 				WormStats& w = stats.worms[i];
 				cell c(p);
@@ -144,9 +144,9 @@ struct StatsRenderer
 		hblock(11, [this, name, &stat] {
 			common.font.drawText(
 				renderer.screenBmp,
-				cell(cell::right).ref() << name, 160 + offsX, y, textColor);
+				cell(cell::right).ref() << name, renderer.renderResX / 2 + offsX, y, textColor);
 
-			int x = 160 + 10 + offsX;
+			int x = renderer.renderResX / 2 + 10 + offsX;
 
 			cell c(cell::left);
 			stat(c);
@@ -268,7 +268,7 @@ void presentStats(NormalStatsRecorder& recorder, Game& game)
 
 	vector<double> wormDamages[2], wormTotalHp[2];
 
-	int const graphWidth = 280;
+	int const graphWidth = renderer.paneWidth - 20;
 
 	for (int i = 0; i < 2; ++i)
 	{
@@ -303,7 +303,7 @@ void presentStats(NormalStatsRecorder& recorder, Game& game)
 	{
 		gfx.screenBmp.copy(bg);
 
-		int offsX = (int)std::floor(pane * -320);
+		int offsX = (int)std::floor(pane * -renderer.renderer.renderResX);
 		int offsY = (int)offset;
 
 		renderer.pane(0, offsX, offsY, [&] {

--- a/gfx.cpp
+++ b/gfx.cpp
@@ -677,9 +677,9 @@ void Gfx::flip()
 
 	{
 		int offsetX, offsetY;
-		int mag = fitScreen(back->w, back->h, internalResX, internalResY, offsetX, offsetY);
+		int mag = fitScreen(back->w, back->h, renderResX, renderResY, offsetX, offsetY);
 		
-		gvl::rect newRect(offsetX, offsetY, internalResX * mag, internalResY * mag);
+		gvl::rect newRect(offsetX, offsetY, renderResX * mag, renderResY * mag);
 		
 		if(mag != prevMag)
 		{
@@ -704,7 +704,7 @@ void Gfx::flip()
 
 			preparePalette(back->format, realPal, pal32);
 
-			scaleDraw(src, internalResX, internalResY, srcPitch, dest, destPitch, mag, pal32);
+			scaleDraw(src, renderResX, renderResY, srcPitch, dest, destPitch, mag, pal32);
 		}
 	}
 	
@@ -1184,8 +1184,8 @@ int Gfx::selectReplay()
 				controller.reset();
 
 				if (settings->singleScreenReplay) {
-					internalResX = 640;
-					internalResY = 400;
+					renderResX = 640;
+					renderResY = 400;
 				}
 
 				controller.reset(new ReplayController(common, sel->getFsNode().toSource()));
@@ -1686,8 +1686,8 @@ restart:
 		}
 
 		// reset internal resolution upon exiting any game
-		internalResX = 320;
-		internalResY = 200;	
+		renderResX = 320;
+		renderResY = 200;	
 		
 		controller->unfocus();
 		

--- a/gfx.cpp
+++ b/gfx.cpp
@@ -351,6 +351,7 @@ void Gfx::loadMenus()
 	hiddenMenu.addItem(MenuItem(48, 7, "PALETTE", HiddenMenu::PaletteSelect));
 	hiddenMenu.addItem(MenuItem(48, 7, "BOT WEAPONS", HiddenMenu::SelectBotWeapons));
 	hiddenMenu.addItem(MenuItem(48, 7, "SEE SPAWN POINT", HiddenMenu::AllowViewingSpawnPoint));
+	hiddenMenu.addItem(MenuItem(48, 7, "SINGLE SCREEN REPLAY", HiddenMenu::SingleScreenReplay));
 
 	playerMenu.addItem(MenuItem(3, 7, "PROFILE LOADED", PlayerMenu::PlLoadedProfile));
 	playerMenu.addItem(MenuItem(3, 7, "SAVE PROFILE", PlayerMenu::PlSaveProfile));
@@ -676,9 +677,9 @@ void Gfx::flip()
 
 	{
 		int offsetX, offsetY;
-		int mag = fitScreen(back->w, back->h, screenBmp.w, screenBmp.h, offsetX, offsetY);
+		int mag = fitScreen(back->w, back->h, internalResX, internalResY, offsetX, offsetY);
 		
-		gvl::rect newRect(offsetX, offsetY, screenBmp.w * mag, screenBmp.h * mag);
+		gvl::rect newRect(offsetX, offsetY, internalResX * mag, internalResY * mag);
 		
 		if(mag != prevMag)
 		{
@@ -702,8 +703,8 @@ void Gfx::flip()
 			uint32_t pal32[256];
 
 			preparePalette(back->format, realPal, pal32);
-		
-			scaleDraw(src, 320, 200, srcPitch, dest, destPitch, mag, pal32);
+
+			scaleDraw(src, internalResX, internalResY, srcPitch, dest, destPitch, mag, pal32);
 		}
 	}
 	
@@ -1181,7 +1182,12 @@ int Gfx::selectReplay()
 
 				// Reset controller before opening the replay, since we may be recording it
 				controller.reset();
-				
+
+				if (settings->singleScreenReplay) {
+					internalResX = 640;
+					internalResY = 400;
+				}
+
 				controller.reset(new ReplayController(common, sel->getFsNode().toSource()));
 				
 				return MainMenu::MaReplay;
@@ -1678,6 +1684,10 @@ restart:
 			flip();
 			process(controller.get());
 		}
+
+		// reset internal resolution upon exiting any game
+		internalResX = 320;
+		internalResY = 200;	
 		
 		controller->unfocus();
 		

--- a/gfx.hpp
+++ b/gfx.hpp
@@ -247,8 +247,6 @@ struct Gfx : Renderer
 	Uint32 lastFrame;
 	unsigned menuCycles;
 	int windowW, windowH;
-	int internalResX = 320; // Resolution used internally
-	int internalResY = 200;
 	int prevMag; // Previous magnification used for drawing
 	gvl::rect lastUpdateRect; // Last region that was updated when flipping
 	gvl::shared_ptr<Common> common;

--- a/gfx.hpp
+++ b/gfx.hpp
@@ -247,6 +247,8 @@ struct Gfx : Renderer
 	Uint32 lastFrame;
 	unsigned menuCycles;
 	int windowW, windowH;
+	int internalResX = 320; // Resolution used internally
+	int internalResY = 200;
 	int prevMag; // Previous magnification used for drawing
 	gvl::rect lastUpdateRect; // Last region that was updated when flipping
 	gvl::shared_ptr<Common> common;

--- a/gfx/font.hpp
+++ b/gfx/font.hpp
@@ -25,6 +25,14 @@ struct Font
 	int getDims(char const* str, std::size_t len, int* height = 0);
 	void drawChar(Bitmap& scr, unsigned char ch, int x, int y, int color);
 	
+	// draws text with a simple shadow underneath it, so even text that would blend into the background can
+	// be displayed
+	void drawShadowedText(Bitmap& scr, std::string const& str, int x, int y, int color)
+	{
+		drawText(scr, str, x + 1, y + 1, color / 2);
+		drawText(scr, str, x, y, color);
+	}
+
 	void drawText(Bitmap& scr, std::string const& str, int x, int y, int color)
 	{
 		drawText(scr, str.data(), str.size(), x, y, color);

--- a/gfx/renderer.cpp
+++ b/gfx/renderer.cpp
@@ -4,7 +4,7 @@
 
 void Renderer::init()
 {
-	screenBmp.alloc(320, 200);
+	screenBmp.alloc(640, 480);
 }
 
 void Renderer::loadPalette(Common const& common)

--- a/gfx/renderer.hpp
+++ b/gfx/renderer.hpp
@@ -18,6 +18,10 @@ struct Renderer
 
 	Rand rand; // PRNG for things that don't affect the game
 	Bitmap screenBmp;
+ 	// Resolution to render at. In effect, this determines how much of screenBmp is used. These may
+ 	// not be larger than screenBmp.x and screenBmp.y
+	int renderResX = 320;
+	int renderResY = 200;
 	Palette pal, origpal;
 	int fadeValue;
 };

--- a/menu/hiddenMenu.cpp
+++ b/menu/hiddenMenu.cpp
@@ -48,6 +48,8 @@ ItemBehavior* HiddenMenu::getItemBehavior(Common& common, MenuItem& item)
 			return new IntegerBehavior(common, gfx.settings->aiParallels, 1, 16);
 		case AllowViewingSpawnPoint:
 			return new BooleanSwitchBehavior(common, gfx.settings->allowViewingSpawnPoint);
+		case SingleScreenReplay:
+			return new BooleanSwitchBehavior(common, gfx.settings->singleScreenReplay);
 
 		default:
 			return Menu::getItemBehavior(common, item);

--- a/menu/hiddenMenu.hpp
+++ b/menu/hiddenMenu.hpp
@@ -26,6 +26,7 @@ struct HiddenMenu : Menu
 		AiTraces,
 		AiParallels,
 		AllowViewingSpawnPoint,
+		SingleScreenReplay,
 	};
 	
 	HiddenMenu(int x, int y)

--- a/settings.cpp
+++ b/settings.cpp
@@ -31,6 +31,7 @@ Extensions::Extensions()
 , zoneTimeout(30)
 , selectBotWeapons(true)
 , allowViewingSpawnPoint(false)
+, singleScreenReplay(false)
 {
 }
 

--- a/settings.hpp
+++ b/settings.hpp
@@ -15,7 +15,7 @@
 // It can then easily reset the extensions if they fail to load.
 struct Extensions
 {
-	static int const myVersion = 6;
+	static int const myVersion = 7;
 	static bool const extensions = true;
 
 	Extensions();
@@ -36,6 +36,7 @@ struct Extensions
 	uint32_t selectBotWeapons;
 
 	bool allowViewingSpawnPoint;
+	bool singleScreenReplay;
 };
 
 struct Rand;
@@ -248,6 +249,9 @@ void archive_liero(Archive ar, Settings& settings, Rand& rand)
 
 		gvl::enable_when(ar, fileExtensionVersion >= 6)
 			.b(settings.allowViewingSpawnPoint, false);
+
+		gvl::enable_when(ar, fileExtensionVersion >= 7)
+			.b(settings.singleScreenReplay, false);
 	}
 	catch(std::runtime_error&)
 	{
@@ -313,6 +317,8 @@ void archive(Archive ar, Settings& settings)
 
 	gvl::enable_when(ar, fileExtensionVersion >= 6)
 		.b(settings.allowViewingSpawnPoint, false);
+	gvl::enable_when(ar, fileExtensionVersion >= 7)
+		.b(settings.singleScreenReplay, false);
 	ar.check();
 }
 
@@ -357,6 +363,7 @@ void archive_text(Settings& settings, Archive& ar)
 	.i32(S(aiParallels));
 
 	ar.b(S(allowViewingSpawnPoint));
+	ar.b(S(singleScreenReplay));
 
 	#undef S
 

--- a/text.hpp
+++ b/text.hpp
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <cstdio>
+#include <cstring>
 
 inline std::string toString(int v)
 {

--- a/viewport.cpp
+++ b/viewport.cpp
@@ -623,7 +623,9 @@ void Viewport::draw(Game& game, Renderer& renderer, bool isReplay)
 	
 	if(game.settings->map)
 	{
-		int const mapX = 134, mapY = 162;
+		int multiplier = renderer.renderResX / 320;
+		int mapX = 134 * multiplier;
+		int mapY = 162 * multiplier;
 
 		game.level.drawMiniature(renderer.screenBmp, mapX, mapY, 10);
 		

--- a/viewport.cpp
+++ b/viewport.cpp
@@ -91,11 +91,13 @@ void Viewport::draw(Game& game, Renderer& renderer, bool isReplay)
 	Common& common = *game.common;
 	Worm& worm = *game.wormByIdx(wormIdx);
 	int multiplier = renderer.renderResX / 320;
+	int centerX = renderer.renderResX / 2;
+	int centerY = renderer.renderResY / 2;
 
 	if(worm.visible)
 	{
 		int lifebarWidth = worm.health * 100 / worm.settings->health;
-		drawBar(renderer.screenBmp, inGameX, 161 * multiplier, lifebarWidth, lifebarWidth/10 + (234 * multiplier));
+		drawBar(renderer.screenBmp, inGameX, renderer.renderResY - 39, lifebarWidth, lifebarWidth / 10 + 234);
 	}
 	else
 	{
@@ -104,7 +106,7 @@ void Viewport::draw(Game& game, Renderer& renderer, bool isReplay)
 		{
 			if(lifebarWidth > 100)
 				lifebarWidth = 100;
-			drawBar(renderer.screenBmp, inGameX, 161 * multiplier, lifebarWidth, lifebarWidth/10 + (234 * multiplier));
+			drawBar(renderer.screenBmp, inGameX, renderer.renderResY - 39, lifebarWidth, lifebarWidth / 10 + 234);
 		}
 	}
 	
@@ -119,7 +121,7 @@ void Viewport::draw(Game& game, Renderer& renderer, bool isReplay)
 			int ammoBarWidth = ww.ammo * 100 / ww.type->ammo;
 			
 			if(ammoBarWidth > 0)
-				drawBar(renderer.screenBmp, inGameX, 166 * multiplier, ammoBarWidth, ammoBarWidth/10 + (245 * multiplier));
+				drawBar(renderer.screenBmp, inGameX, renderer.renderResY - 34, ammoBarWidth, ammoBarWidth / 10 + 245);
 		}
 	}
 	else
@@ -137,7 +139,7 @@ void Viewport::draw(Game& game, Renderer& renderer, bool isReplay)
 		}
 		
 		if(ammoBarWidth > 0)
-			drawBar(renderer.screenBmp, inGameX, 166 * multiplier, ammoBarWidth, multiplier * ammoBarWidth/10 + (245 * multiplier));
+			drawBar(renderer.screenBmp, inGameX, renderer.renderResY - 34, ammoBarWidth, ammoBarWidth / 10 + 245);
 		
 		if((game.cycles % 20) > 10
 		&& worm.visible)
@@ -146,12 +148,12 @@ void Viewport::draw(Game& game, Renderer& renderer, bool isReplay)
 		}
 	}
 	
-	common.font.drawText(renderer.screenBmp, (LS(Kills) + toString(worm.kills)), inGameX, 171 * multiplier, 10);
+	common.font.drawText(renderer.screenBmp, (LS(Kills) + toString(worm.kills)), inGameX, renderer.renderResY - 29, 10);
 	
 	if(isReplay)
 	{
-		common.font.drawText(renderer.screenBmp, worm.settings->name, inGameX, 192 * multiplier, 4);
-		common.font.drawText(renderer.screenBmp, timeToStringEx(game.cycles * 14), 95 * multiplier, 185 * multiplier, 7);
+		common.font.drawText(renderer.screenBmp, worm.settings->name, inGameX, renderer.renderResY - 8, 4);
+		common.font.drawText(renderer.screenBmp, timeToStringEx(game.cycles * 14), 95 * multiplier, renderer.renderResY - 15, 7);
 	}
 
 	int const stateColours[2][2] = {{6, 10}, {79, 4}};
@@ -161,7 +163,7 @@ void Viewport::draw(Game& game, Renderer& renderer, bool isReplay)
 	case Settings::GMKillEmAll:
 	case Settings::GMScalesOfJustice:
 	{
-		common.font.drawText(renderer.screenBmp, (LS(Lives) + toString(worm.lives)), inGameX, 178 * multiplier, 6);
+		common.font.drawText(renderer.screenBmp, (LS(Lives) + toString(worm.lives)), inGameX, renderer.renderResY - 22, 6);
 	}
 	break;
 
@@ -175,7 +177,7 @@ void Viewport::draw(Game& game, Renderer& renderer, bool isReplay)
 		
 		int color = stateColours[game.holdazone.holderIdx != worm.index][state];
 		
-		common.font.drawText(renderer.screenBmp, timeToString(worm.timer), 5 * multiplier, 106 + 84*worm.index * multiplier, 161 * multiplier, color);
+		common.font.drawText(renderer.screenBmp, timeToString(worm.timer), 5 * multiplier, 106 + 84 * worm.index * multiplier, renderer.renderResY - 39, color);
 	}
 	break;
 	
@@ -189,7 +191,7 @@ void Viewport::draw(Game& game, Renderer& renderer, bool isReplay)
 
 		int color = stateColours[game.lastKilledIdx != worm.index][state];
 		
-		common.font.drawText(renderer.screenBmp, timeToString(worm.timer), 5 * multiplier, 106 + 84 * worm.index * multiplier, 161 * multiplier, color);
+		common.font.drawText(renderer.screenBmp, timeToString(worm.timer), 5 * multiplier, 106 + 84 * worm.index * multiplier, renderer.renderResY - 39, color);
 	}
 	break;
 	}
@@ -624,8 +626,8 @@ void Viewport::draw(Game& game, Renderer& renderer, bool isReplay)
 	
 	if(game.settings->map)
 	{
-		int mapX = 134 * multiplier;
-		int mapY = 162 * multiplier;
+		int mapX = centerX - 26;
+		int mapY = renderer.renderResY - 38;
 
 		game.level.drawMiniature(renderer.screenBmp, mapX, mapY, 10);
 		

--- a/viewport.cpp
+++ b/viewport.cpp
@@ -151,7 +151,7 @@ void Viewport::draw(Game& game, Renderer& renderer, bool isReplay)
 	
 	if(isReplay)
 	{
-		common.font.drawText(renderer.screenBmp, worm.settings->name, inGameX, renderer.renderResY - 8, 4);
+		common.font.drawShadowedText(renderer.screenBmp, worm.settings->name, inGameX, renderer.renderResY - 8, worm.settings->color);
 		common.font.drawText(renderer.screenBmp, timeToStringEx(game.cycles * 14), 95 * multiplier, renderer.renderResY - 15, 7);
 	}
 

--- a/viewport.cpp
+++ b/viewport.cpp
@@ -177,7 +177,7 @@ void Viewport::draw(Game& game, Renderer& renderer, bool isReplay)
 		
 		int color = stateColours[game.holdazone.holderIdx != worm.index][state];
 		
-		common.font.drawText(renderer.screenBmp, timeToString(worm.timer), 5 * multiplier, 106 + 84 * worm.index * multiplier, renderer.renderResY - 39, color);
+		common.font.drawText(renderer.screenBmp, timeToString(worm.timer), 5 * multiplier, 106 * multiplier + 84 * worm.index * multiplier, renderer.renderResY - 39, color);
 	}
 	break;
 	
@@ -191,7 +191,7 @@ void Viewport::draw(Game& game, Renderer& renderer, bool isReplay)
 
 		int color = stateColours[game.lastKilledIdx != worm.index][state];
 		
-		common.font.drawText(renderer.screenBmp, timeToString(worm.timer), 5 * multiplier, 106 + 84 * worm.index * multiplier, renderer.renderResY - 39, color);
+		common.font.drawText(renderer.screenBmp, timeToString(worm.timer), 5 * multiplier, 106 * multiplier + 84 * worm.index * multiplier, renderer.renderResY - 39, color);
 	}
 	break;
 	}

--- a/viewport.cpp
+++ b/viewport.cpp
@@ -90,11 +90,12 @@ void Viewport::draw(Game& game, Renderer& renderer, bool isReplay)
 {
 	Common& common = *game.common;
 	Worm& worm = *game.wormByIdx(wormIdx);
+	int multiplier = renderer.renderResX / 320;
 
 	if(worm.visible)
 	{
 		int lifebarWidth = worm.health * 100 / worm.settings->health;
-		drawBar(renderer.screenBmp, inGameX, 161, lifebarWidth, lifebarWidth/10 + 234);
+		drawBar(renderer.screenBmp, inGameX, 161 * multiplier, lifebarWidth, lifebarWidth/10 + (234 * multiplier));
 	}
 	else
 	{
@@ -103,7 +104,7 @@ void Viewport::draw(Game& game, Renderer& renderer, bool isReplay)
 		{
 			if(lifebarWidth > 100)
 				lifebarWidth = 100;
-			drawBar(renderer.screenBmp, inGameX, 161, lifebarWidth, lifebarWidth/10 + 234);
+			drawBar(renderer.screenBmp, inGameX, 161 * multiplier, lifebarWidth, lifebarWidth/10 + (234 * multiplier));
 		}
 	}
 	
@@ -118,7 +119,7 @@ void Viewport::draw(Game& game, Renderer& renderer, bool isReplay)
 			int ammoBarWidth = ww.ammo * 100 / ww.type->ammo;
 			
 			if(ammoBarWidth > 0)
-				drawBar(renderer.screenBmp, inGameX, 166, ammoBarWidth, ammoBarWidth/10 + 245);
+				drawBar(renderer.screenBmp, inGameX, 166 * multiplier, ammoBarWidth, ammoBarWidth/10 + (245 * multiplier));
 		}
 	}
 	else
@@ -136,21 +137,21 @@ void Viewport::draw(Game& game, Renderer& renderer, bool isReplay)
 		}
 		
 		if(ammoBarWidth > 0)
-			drawBar(renderer.screenBmp, inGameX, 166, ammoBarWidth, ammoBarWidth/10 + 245);
+			drawBar(renderer.screenBmp, inGameX, 166 * multiplier, ammoBarWidth, multiplier * ammoBarWidth/10 + (245 * multiplier));
 		
 		if((game.cycles % 20) > 10
 		&& worm.visible)
 		{
-			common.font.drawText(renderer.screenBmp, LS(Reloading), inGameX, 164, 50);
+			common.font.drawText(renderer.screenBmp, LS(Reloading), inGameX, 164 * multiplier, 50);
 		}
 	}
 	
-	common.font.drawText(renderer.screenBmp, (LS(Kills) + toString(worm.kills)), inGameX, 171, 10);
+	common.font.drawText(renderer.screenBmp, (LS(Kills) + toString(worm.kills)), inGameX, 171 * multiplier, 10);
 	
 	if(isReplay)
 	{
-		common.font.drawText(renderer.screenBmp, worm.settings->name, inGameX, 192, 4);
-		common.font.drawText(renderer.screenBmp, timeToStringEx(game.cycles * 14), 95, 185, 7);
+		common.font.drawText(renderer.screenBmp, worm.settings->name, inGameX, 192 * multiplier, 4);
+		common.font.drawText(renderer.screenBmp, timeToStringEx(game.cycles * 14), 95 * multiplier, 185 * multiplier, 7);
 	}
 
 	int const stateColours[2][2] = {{6, 10}, {79, 4}};
@@ -160,7 +161,7 @@ void Viewport::draw(Game& game, Renderer& renderer, bool isReplay)
 	case Settings::GMKillEmAll:
 	case Settings::GMScalesOfJustice:
 	{
-		common.font.drawText(renderer.screenBmp, (LS(Lives) + toString(worm.lives)), inGameX, 178, 6);
+		common.font.drawText(renderer.screenBmp, (LS(Lives) + toString(worm.lives)), inGameX, 178 * multiplier, 6);
 	}
 	break;
 
@@ -174,7 +175,7 @@ void Viewport::draw(Game& game, Renderer& renderer, bool isReplay)
 		
 		int color = stateColours[game.holdazone.holderIdx != worm.index][state];
 		
-		common.font.drawText(renderer.screenBmp, timeToString(worm.timer), 5, 106 + 84*worm.index, 161, color);
+		common.font.drawText(renderer.screenBmp, timeToString(worm.timer), 5 * multiplier, 106 + 84*worm.index * multiplier, 161 * multiplier, color);
 	}
 	break;
 	
@@ -188,7 +189,7 @@ void Viewport::draw(Game& game, Renderer& renderer, bool isReplay)
 
 		int color = stateColours[game.lastKilledIdx != worm.index][state];
 		
-		common.font.drawText(renderer.screenBmp, timeToString(worm.timer), 5, 106 + 84*worm.index, 161, color);
+		common.font.drawText(renderer.screenBmp, timeToString(worm.timer), 5 * multiplier, 106 + 84 * worm.index * multiplier, 161 * multiplier, color);
 	}
 	break;
 	}
@@ -623,7 +624,6 @@ void Viewport::draw(Game& game, Renderer& renderer, bool isReplay)
 	
 	if(game.settings->map)
 	{
-		int multiplier = renderer.renderResX / 320;
 		int mapX = 134 * multiplier;
 		int mapY = 162 * multiplier;
 

--- a/viewport.cpp
+++ b/viewport.cpp
@@ -92,7 +92,6 @@ void Viewport::draw(Game& game, Renderer& renderer, bool isReplay)
 	Worm& worm = *game.wormByIdx(wormIdx);
 	int multiplier = renderer.renderResX / 320;
 	int centerX = renderer.renderResX / 2;
-	int centerY = renderer.renderResY / 2;
 
 	if(worm.visible)
 	{


### PR DESCRIPTION
This implements a new optional feature (disabled by default) which I call single screen replays. A video demo: https://www.youtube.com/watch?v=fnH1gdtsoo4

When this is turned on, replays will display the full map, and the normal "split screen" is turned off. A resolution of at least 640x480 is required for this to work correctly, else it just displays a black screen. I haven't spent any time handling issues that may occur as an effect of running this at a too low resolution..

The patch is not intended to affect regular gameplay. However, since it touches some drawing code there's some risk of introducing display issues.

This branch also includes some other patches. If you prefer I can resubmit them as separate pull requests:
- f5c99e6, which re-enables sounds in replays. It looks like this was disabled by mistake as a part of 4373c02.
- two compile fixes for gcc on linux
- drawing of player name in player color in the replay. Due to player colors potentially being black or very dark, this adds a rudimentary shadow on every name as well.
