### PR TITLE
Single screen replay

### DIFF
--- a/controller/replayController.cpp
+++ b/controller/replayController.cpp
@@ -41,11 +41,7 @@ void ReplayController::focus()
 	{
 		try
 		{
-#if 1 // TEMP
-			game = replay->beginPlayback(common, gvl::shared_ptr<SoundPlayer>(new NullSoundPlayer()));
-#else
 			game = replay->beginPlayback(common, gvl::shared_ptr<SoundPlayer>(new DefaultSoundPlayer(*common)));
-#endif
 		}
 		catch(std::runtime_error& e)
 		{

--- a/controller/replayController.cpp
+++ b/controller/replayController.cpp
@@ -2,6 +2,7 @@
 
 #include "../game.hpp"
 #include "stats_presenter.hpp"
+#include "../viewport.hpp"
 #include "../sfx.hpp"
 
 ReplayController::ReplayController(
@@ -154,6 +155,13 @@ void ReplayController::changeState(State newState)
 
 	if(newState == StateGame)
 	{
+		if (gfx.settings->singleScreenReplay) {
+			game->clearViewports();
+			// +68 on x to align the viewport in the middle
+			game->addViewport(new Viewport(gvl::rect(0, 0, 504 + 68, 350), game->worms[0]->index, 0, 504, 350));
+			// TODO: a bit weird to duplicate this, but it's needed to draw health bars etc
+			game->addViewport(new Viewport(gvl::rect(0, 0, 504 + 68, 350), game->worms[1]->index, 538, 504, 350));
+		}
 		game->startGame();
 #if !ENABLE_TRACING
 		initialGame.reset(new Game(*game));

--- a/controller/stats_presenter.cpp
+++ b/controller/stats_presenter.cpp
@@ -35,19 +35,19 @@ struct StatsRenderer
 	, game(game)
 	, stats(stats)
 	, common(common)
+	, paneWidth(renderer.renderResX - 20)
 	{
-
 	}
 
 	static int const paneX = 10;
-	static int const paneWidth = 320-20;
+	int paneWidth = 300;
 
 	template<typename P>
 	void pane(int n, int leftX, int topY, P const& p)
 	{
-		offsX = n * 320 + leftX;
+		offsX = n * renderer.renderResX + leftX;
 
-		if (offsX >= -320 && offsX < 320)
+		if (offsX >= -renderer.renderResX && offsX < renderer.renderResX)
 		{
 			y = topY;
 			y += 10;
@@ -64,7 +64,7 @@ struct StatsRenderer
 	bool hblock(int height, B const& b)
 	{
 		bool ran = false;
-		if (y < 200
+		if (y < renderer.renderResY
 		 && y + height > 0)
 		{
 			b();
@@ -79,7 +79,7 @@ struct StatsRenderer
 		hblock(20, [this] {
 			for (int i = 0; i < 2; ++i)
 			{
-				int x = 160 + (i == 0 ? -1 : 1) * (160 / 2) + offsX;
+				int x = renderer.renderResX / 2 + (i == 0 ? -1 : 1) * (renderer.renderResX / 4) + offsX;
 				blitImage(renderer.screenBmp, common.wormSpriteObj(2, i == 0 ? 1 : 0, i), x - 8, y);
 
 				cell c(i == 0 ? cell::right : cell::left);
@@ -96,7 +96,7 @@ struct StatsRenderer
 	void drawWorm(int i)
 	{
 		bool visible = hblock(20, [this, i] {
-			int x = 160 + offsX;
+			int x = renderer.renderResX / 2 + offsX;
 			blitImage(renderer.screenBmp, common.wormSpriteObj(2, i == 0 ? 1 : 0, i), x - 8, y);
 
 			cell c(i == 0 ? cell::right : cell::left);
@@ -121,12 +121,12 @@ struct StatsRenderer
 		hblock(11, [this, name, &wormStat] {
 			common.font.drawText(
 				renderer.screenBmp,
-				cell(cell::center).ref() << name, 160 + offsX, y, textColor);
+				cell(cell::center).ref() << name, renderer.renderResX / 2 + offsX, y, textColor);
 
 			for (int i = 0; i < 2; ++i)
 			{
 				cell::placement p = i == 0 ? cell::right : cell::left;
-				int x = 160 + (i == 0 ? -40 : 40) + offsX;
+				int x = renderer.renderResX / 2 + (i == 0 ? -40 : 40) + offsX;
 
 				WormStats& w = stats.worms[i];
 				cell c(p);
@@ -144,9 +144,9 @@ struct StatsRenderer
 		hblock(11, [this, name, &stat] {
 			common.font.drawText(
 				renderer.screenBmp,
-				cell(cell::right).ref() << name, 160 + offsX, y, textColor);
+				cell(cell::right).ref() << name, renderer.renderResX / 2 + offsX, y, textColor);
 
-			int x = 160 + 10 + offsX;
+			int x = renderer.renderResX / 2 + 10 + offsX;
 
 			cell c(cell::left);
 			stat(c);
@@ -268,7 +268,7 @@ void presentStats(NormalStatsRecorder& recorder, Game& game)
 
 	vector<double> wormDamages[2], wormTotalHp[2];
 
-	int const graphWidth = 280;
+	int const graphWidth = renderer.paneWidth - 20;
 
 	for (int i = 0; i < 2; ++i)
 	{
@@ -303,7 +303,7 @@ void presentStats(NormalStatsRecorder& recorder, Game& game)
 	{
 		gfx.screenBmp.copy(bg);
 
-		int offsX = (int)std::floor(pane * -320);
+		int offsX = (int)std::floor(pane * -renderer.renderer.renderResX);
 		int offsY = (int)offset;
 
 		renderer.pane(0, offsX, offsY, [&] {

--- a/gfx.cpp
+++ b/gfx.cpp
@@ -351,6 +351,7 @@ void Gfx::loadMenus()
 	hiddenMenu.addItem(MenuItem(48, 7, "PALETTE", HiddenMenu::PaletteSelect));
 	hiddenMenu.addItem(MenuItem(48, 7, "BOT WEAPONS", HiddenMenu::SelectBotWeapons));
 	hiddenMenu.addItem(MenuItem(48, 7, "SEE SPAWN POINT", HiddenMenu::AllowViewingSpawnPoint));
+	hiddenMenu.addItem(MenuItem(48, 7, "SINGLE SCREEN REPLAY", HiddenMenu::SingleScreenReplay));
 
 	playerMenu.addItem(MenuItem(3, 7, "PROFILE LOADED", PlayerMenu::PlLoadedProfile));
 	playerMenu.addItem(MenuItem(3, 7, "SAVE PROFILE", PlayerMenu::PlSaveProfile));
@@ -676,9 +677,9 @@ void Gfx::flip()
 
 	{
 		int offsetX, offsetY;
-		int mag = fitScreen(back->w, back->h, screenBmp.w, screenBmp.h, offsetX, offsetY);
+		int mag = fitScreen(back->w, back->h, renderResX, renderResY, offsetX, offsetY);
 
-		gvl::rect newRect(offsetX, offsetY, screenBmp.w * mag, screenBmp.h * mag);
+		gvl::rect newRect(offsetX, offsetY, renderResX * mag, renderResY * mag);
 
 		if(mag != prevMag)
 		{
@@ -703,7 +704,7 @@ void Gfx::flip()
 
 			preparePalette(back->format, realPal, pal32);
 
-			scaleDraw(src, 320, 200, srcPitch, dest, destPitch, mag, pal32);
+			scaleDraw(src, renderResX, renderResY, srcPitch, dest, destPitch, mag, pal32);
 		}
 	}
 
@@ -1181,6 +1182,11 @@ int Gfx::selectReplay()
 
 				// Reset controller before opening the replay, since we may be recording it
 				controller.reset();
+
+				if (settings->singleScreenReplay) {
+					renderResX = 640;
+					renderResY = 400;
+				}
 
 				controller.reset(new ReplayController(common, sel->getFsNode().toSource()));
 
@@ -1678,6 +1684,10 @@ restart:
 			flip();
 			process(controller.get());
 		}
+
+		// reset internal resolution upon exiting any game
+		renderResX = 320;
+		renderResY = 200;
 
 		controller->unfocus();
 

--- a/gfx/font.hpp
+++ b/gfx/font.hpp
@@ -25,6 +25,14 @@ struct Font
 	int getDims(char const* str, std::size_t len, int* height = 0);
 	void drawChar(Bitmap& scr, unsigned char ch, int x, int y, int color);
 
+	// draws text with a simple shadow underneath it, so even text that would blend into the background can
+	// be displayed
+	void drawShadowedText(Bitmap& scr, std::string const& str, int x, int y, int color)
+	{
+		drawText(scr, str, x + 1, y + 1, color / 2);
+		drawText(scr, str, x, y, color);
+	}
+
 	void drawText(Bitmap& scr, std::string const& str, int x, int y, int color)
 	{
 		drawText(scr, str.data(), str.size(), x, y, color);

--- a/gfx/renderer.cpp
+++ b/gfx/renderer.cpp
@@ -4,7 +4,7 @@
 
 void Renderer::init()
 {
-	screenBmp.alloc(320, 200);
+	screenBmp.alloc(640, 480);
 }
 
 void Renderer::loadPalette(Common const& common)

--- a/gfx/renderer.hpp
+++ b/gfx/renderer.hpp
@@ -18,6 +18,10 @@ struct Renderer
 
 	Rand rand; // PRNG for things that don't affect the game
 	Bitmap screenBmp;
+ 	// Resolution to render at. In effect, this determines how much of screenBmp is used. These may
+ 	// not be larger than screenBmp.x and screenBmp.y
+	int renderResX = 320;
+	int renderResY = 200;
 	Palette pal, origpal;
 	int fadeValue;
 };

--- a/menu/hiddenMenu.cpp
+++ b/menu/hiddenMenu.cpp
@@ -48,6 +48,8 @@ ItemBehavior* HiddenMenu::getItemBehavior(Common& common, MenuItem& item)
 			return new IntegerBehavior(common, gfx.settings->aiParallels, 1, 16);
 		case AllowViewingSpawnPoint:
 			return new BooleanSwitchBehavior(common, gfx.settings->allowViewingSpawnPoint);
+		case SingleScreenReplay:
+			return new BooleanSwitchBehavior(common, gfx.settings->singleScreenReplay);
 
 		default:
 			return Menu::getItemBehavior(common, item);

--- a/menu/hiddenMenu.hpp
+++ b/menu/hiddenMenu.hpp
@@ -26,6 +26,7 @@ struct HiddenMenu : Menu
 		AiTraces,
 		AiParallels,
 		AllowViewingSpawnPoint,
+		SingleScreenReplay,
 	};
 
 	HiddenMenu(int x, int y)

--- a/settings.cpp
+++ b/settings.cpp
@@ -31,6 +31,7 @@ Extensions::Extensions()
 , zoneTimeout(30)
 , selectBotWeapons(true)
 , allowViewingSpawnPoint(false)
+, singleScreenReplay(false)
 {
 }
 

--- a/settings.hpp
+++ b/settings.hpp
@@ -15,7 +15,7 @@
 // It can then easily reset the extensions if they fail to load.
 struct Extensions
 {
-	static int const myVersion = 6;
+	static int const myVersion = 7;
 	static bool const extensions = true;
 
 	Extensions();
@@ -36,6 +36,7 @@ struct Extensions
 	uint32_t selectBotWeapons;
 
 	bool allowViewingSpawnPoint;
+	bool singleScreenReplay;
 };
 
 struct Rand;
@@ -248,6 +249,9 @@ void archive_liero(Archive ar, Settings& settings, Rand& rand)
 
 		gvl::enable_when(ar, fileExtensionVersion >= 6)
 			.b(settings.allowViewingSpawnPoint, false);
+
+		gvl::enable_when(ar, fileExtensionVersion >= 7)
+			.b(settings.singleScreenReplay, false);
 	}
 	catch(std::runtime_error&)
 	{
@@ -313,6 +317,8 @@ void archive(Archive ar, Settings& settings)
 
 	gvl::enable_when(ar, fileExtensionVersion >= 6)
 		.b(settings.allowViewingSpawnPoint, false);
+	gvl::enable_when(ar, fileExtensionVersion >= 7)
+		.b(settings.singleScreenReplay, false);
 	ar.check();
 }
 
@@ -357,6 +363,7 @@ void archive_text(Settings& settings, Archive& ar)
 	.i32(S(aiParallels));
 
 	ar.b(S(allowViewingSpawnPoint));
+	ar.b(S(singleScreenReplay));
 
 	#undef S
 

--- a/viewport.cpp
+++ b/viewport.cpp
@@ -623,7 +623,9 @@ void Viewport::draw(Game& game, Renderer& renderer, bool isReplay)
 
 	if(game.settings->map)
 	{
-		int const mapX = 134, mapY = 162;
+		int multiplier = renderer.renderResX / 320;
+		int mapX = 134 * multiplier;
+		int mapY = 162 * multiplier;
 
 		game.level.drawMiniature(renderer.screenBmp, mapX, mapY, 10);
 

--- a/viewport.cpp
+++ b/viewport.cpp
@@ -90,11 +90,13 @@ void Viewport::draw(Game& game, Renderer& renderer, bool isReplay)
 {
 	Common& common = *game.common;
 	Worm& worm = *game.wormByIdx(wormIdx);
+	int multiplier = renderer.renderResX / 320;
+	int centerX = renderer.renderResX / 2;
 
 	if(worm.visible)
 	{
 		int lifebarWidth = worm.health * 100 / worm.settings->health;
-		drawBar(renderer.screenBmp, inGameX, 161, lifebarWidth, lifebarWidth/10 + 234);
+		drawBar(renderer.screenBmp, inGameX, renderer.renderResY - 39, lifebarWidth, lifebarWidth / 10 + 234);
 	}
 	else
 	{
@@ -103,7 +105,7 @@ void Viewport::draw(Game& game, Renderer& renderer, bool isReplay)
 		{
 			if(lifebarWidth > 100)
 				lifebarWidth = 100;
-			drawBar(renderer.screenBmp, inGameX, 161, lifebarWidth, lifebarWidth/10 + 234);
+			drawBar(renderer.screenBmp, inGameX, renderer.renderResY - 39, lifebarWidth, lifebarWidth / 10 + 234);
 		}
 	}
 
@@ -118,7 +120,7 @@ void Viewport::draw(Game& game, Renderer& renderer, bool isReplay)
 			int ammoBarWidth = ww.ammo * 100 / ww.type->ammo;
 
 			if(ammoBarWidth > 0)
-				drawBar(renderer.screenBmp, inGameX, 166, ammoBarWidth, ammoBarWidth/10 + 245);
+				drawBar(renderer.screenBmp, inGameX, renderer.renderResY - 34, ammoBarWidth, ammoBarWidth / 10 + 245);
 		}
 	}
 	else
@@ -136,21 +138,21 @@ void Viewport::draw(Game& game, Renderer& renderer, bool isReplay)
 		}
 
 		if(ammoBarWidth > 0)
-			drawBar(renderer.screenBmp, inGameX, 166, ammoBarWidth, ammoBarWidth/10 + 245);
+			drawBar(renderer.screenBmp, inGameX, renderer.renderResY - 34, ammoBarWidth, ammoBarWidth / 10 + 245);
 
 		if((game.cycles % 20) > 10
 		&& worm.visible)
 		{
-			common.font.drawText(renderer.screenBmp, LS(Reloading), inGameX, 164, 50);
+			common.font.drawText(renderer.screenBmp, LS(Reloading), inGameX, 164 * multiplier, 50);
 		}
 	}
 
-	common.font.drawText(renderer.screenBmp, (LS(Kills) + toString(worm.kills)), inGameX, 171, 10);
+	common.font.drawText(renderer.screenBmp, (LS(Kills) + toString(worm.kills)), inGameX, renderer.renderResY - 29, 10);
 
 	if(isReplay)
 	{
-		common.font.drawText(renderer.screenBmp, worm.settings->name, inGameX, 192, 4);
-		common.font.drawText(renderer.screenBmp, timeToStringEx(game.cycles * 14), 95, 185, 7);
+		common.font.drawShadowedText(renderer.screenBmp, worm.settings->name, inGameX, renderer.renderResY - 8, worm.settings->color);
+		common.font.drawText(renderer.screenBmp, timeToStringEx(game.cycles * 14), 95 * multiplier, renderer.renderResY - 15, 7);
 	}
 
 	int const stateColours[2][2] = {{6, 10}, {79, 4}};
@@ -160,7 +162,7 @@ void Viewport::draw(Game& game, Renderer& renderer, bool isReplay)
 	case Settings::GMKillEmAll:
 	case Settings::GMScalesOfJustice:
 	{
-		common.font.drawText(renderer.screenBmp, (LS(Lives) + toString(worm.lives)), inGameX, 178, 6);
+		common.font.drawText(renderer.screenBmp, (LS(Lives) + toString(worm.lives)), inGameX, renderer.renderResY - 22, 6);
 	}
 	break;
 
@@ -174,7 +176,7 @@ void Viewport::draw(Game& game, Renderer& renderer, bool isReplay)
 
 		int color = stateColours[game.holdazone.holderIdx != worm.index][state];
 
-		common.font.drawText(renderer.screenBmp, timeToString(worm.timer), 5, 106 + 84*worm.index, 161, color);
+		common.font.drawText(renderer.screenBmp, timeToString(worm.timer), 5 * multiplier, 106 * multiplier + 84 * worm.index * multiplier, renderer.renderResY - 39, color);
 	}
 	break;
 
@@ -188,7 +190,7 @@ void Viewport::draw(Game& game, Renderer& renderer, bool isReplay)
 
 		int color = stateColours[game.lastKilledIdx != worm.index][state];
 
-		common.font.drawText(renderer.screenBmp, timeToString(worm.timer), 5, 106 + 84*worm.index, 161, color);
+		common.font.drawText(renderer.screenBmp, timeToString(worm.timer), 5 * multiplier, 106 * multiplier + 84 * worm.index * multiplier, renderer.renderResY - 39, color);
 	}
 	break;
 	}
@@ -286,7 +288,7 @@ void Viewport::draw(Game& game, Renderer& renderer, bool isReplay)
 		}
 
 		auto br = game.bonuses.all();
-		for (Bonus* i; (i = br.next()); )
+		for (Bonus* i; i = br.next(); )
 		{
 			if(i->timer > LC(BonusFlickerTime) || (game.cycles & 3) == 0)
 			{
@@ -325,7 +327,7 @@ void Viewport::draw(Game& game, Renderer& renderer, bool isReplay)
 		}
 
 		auto sr = game.sobjects.all();
-		for (SObject* i; (i = sr.next()); )
+		for (SObject* i; i = sr.next(); )
 		{
 			SObjectType const& t = common.sobjectTypes[i->id];
 			int frame = i->curFrame + t.startFrame;
@@ -350,7 +352,7 @@ void Viewport::draw(Game& game, Renderer& renderer, bool isReplay)
 		}
 
 		auto wr = game.wobjects.all();
-		for (WObject* i; (i = wr.next()); )
+		for (WObject* i; i = wr.next(); )
 		{
 			Weapon const& w = *i->type;
 
@@ -443,7 +445,7 @@ void Viewport::draw(Game& game, Renderer& renderer, bool isReplay)
 		}
 
 		auto nr = game.nobjects.all();
-		for (NObject* i; (i = nr.next()); )
+		for (NObject* i; i = nr.next(); )
 		{
 			NObjectType const& t = *i->type;
 
@@ -623,9 +625,8 @@ void Viewport::draw(Game& game, Renderer& renderer, bool isReplay)
 
 	if(game.settings->map)
 	{
-		int multiplier = renderer.renderResX / 320;
-		int mapX = 134 * multiplier;
-		int mapY = 162 * multiplier;
+		int mapX = centerX - 26;
+		int mapY = renderer.renderResY - 38;
 
 		game.level.drawMiniature(renderer.screenBmp, mapX, mapY, 10);
 


### PR DESCRIPTION
This adds an option for enabling replays on a single screen. See e.g. https://www.youtube.com/watch?v=l2yi60-grHs

This is a part of #26.

NOTE: I have not verified that this code works. It looks fine, and I think it worked at one time, but it might not. My plan is to follow up with SDL 2 patches that should definitely work, and then follow up with fixes that actually makes stuff possible to build.