### PR TITLE
Experimental ARM support

### DIFF
--- a/src/tl/platform.h
+++ b/src/tl/platform.h
@@ -60,13 +60,17 @@
 #  define TL_X86_64 1
 # elif defined(__i386__) || defined(_M_IX86) || defined(i386) || defined(i486) || defined(intel) || defined(x86) || defined(i86pc)
 #  define TL_X86 1
+# elif defined(__arm__) || defined(_M_ARM)
+#  define TL_ARM 1
+# elif defined(__aarch_64__) || defined(_M_ARM64)
+#  define TL_ARM_64 1
 # else
 #  error "Unknown architecture, please add it"
 # endif
 #endif
 
 #if !TL_LITTLE_ENDIAN && !TL_BIG_ENDIAN
-# if TL_X86 || TL_X86_64
+# if TL_X86 || TL_X86_64 || TL_ARM || TL_ARM64
 #  define TL_LITTLE_ENDIAN 1
 # else
 #  define TL_BIG_ENDIAN 1
@@ -115,7 +119,7 @@
 #if !defined(TL_X87)
 # if TL_X86
 #  define TL_X87 1 // Assume the compiler generates x87 code on x86 unless otherwise stated
-# elif TL_X86_64
+# elif defined(TL_X86_64) || defined(TL_ARM) || defined(TL_ARM_64)
 #  define TL_X87 0 // SSE2 is typically used on TL_X86_64
 # endif
 #endif


### PR DESCRIPTION
It can convert a TC, and it starts, but my raspberry pi isn't setup for running graphical applications, so I can't verify this all the way.

According to documentation ARM is bi-endian but usually uses little-endian, and it's little-endian on my raspberry pi so let's assume this will work until it doesn't.

This might resolve #19. If it doesn't, I'd be happy to help someone who is more personally invested in ARM support (hello Macbook users ;)) in getting this running (I'd be surprised if it was any substantial work).