### PR TITLE
Use SDL_GameController instead of SDL_Joystick

### DIFF
--- a/src/game/gfx.cpp
+++ b/src/game/gfx.cpp
@@ -297,12 +297,12 @@ void Gfx::init()
 
 	playRenderer.init(320, 200);
 	singleScreenRenderer.init(640, 400);
-	// Joystick init:
-	SDL_JoystickEventState(SDL_ENABLE);
+	// Joystick init
+	SDL_GameControllerEventState(SDL_ENABLE);
 	int numJoysticks = SDL_NumJoysticks();
 	joysticks.resize(numJoysticks);
 	for ( int i = 0; i < numJoysticks; ++i ) {
-		joysticks[i].sdlJoystick = SDL_JoystickOpen(i);
+		joysticks[i].sdlGameController= SDL_GameControllerOpen(i);
 		joysticks[i].clearState();
 	}
 }

--- a/src/game/gfx.hpp
+++ b/src/game/gfx.hpp
@@ -106,7 +106,7 @@ struct SettingsMenu : Menu
 };
 
 struct Joystick {
-	SDL_Joystick *sdlJoystick;
+	SDL_GameController *sdlGameController;
 	bool btnState[MaxJoyButtons];
 
 	void clearState() {

--- a/src/game/main.cpp
+++ b/src/game/main.cpp
@@ -111,7 +111,7 @@ try
 	if(!tcSet)
 		tcName = "Liero v1.33";
 
-	SDL_Init(SDL_INIT_VIDEO | SDL_INIT_JOYSTICK);
+	SDL_Init(SDL_INIT_VIDEO | SDL_INIT_GAMECONTROLLER);
 
 	initKeys();
 


### PR DESCRIPTION
Shouldn't matter for our usage, but it's the more modern option.

I have verified that this works with my xbox-compatible controller, both using the directional pad and the analog controls.