### PR TITLE
Added support for Apple Silicon

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,7 @@ target_link_libraries(videotool SDL2::SDL2 avcodec avformat avutil dl pthread sw
 include_directories(src/game)
 
 if(APPLE)
+    target_link_libraries(openliero "-framework Cocoa" "-framework CoreFoundation")
     set_target_properties(openliero PROPERTIES MACOSX_BUNDLE TRUE)
     set_target_properties(openliero PROPERTIES MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_SOURCE_DIR}/Info.plist.in")
     set(MACOSX_BUNDLE_ICON_FILE liero)

--- a/src/game/SDLMain.m
+++ b/src/game/SDLMain.m
@@ -8,6 +8,7 @@
 #include "SDL.h"
 #include "SDLMain.h"
 #include <sys/param.h> /* for MAXPATHLEN */
+#include <sys/stat.h>
 #include <unistd.h>
 
 /* For some reaon, Apple removed setAppleMenu from the headers in 10.4,
@@ -81,9 +82,14 @@ static NSString *getApplicationName(void)
 /* The main class of the application, the application's delegate */
 @implementation SDLMain
 
-/* Set the working directory to the .app's Resources directory, for config file loading */
+/* Set the working directory to the .app's Resources directory, for config file loading,
+   unless TC data already exists in the current working directory (e.g. running from source). */
 - (void) setupWorkingDirectory
 {
+    struct stat st;
+    if (stat("TC", &st) == 0 && S_ISDIR(st.st_mode)) {
+        return; /* TC data found in cwd, no need to chdir */
+    }
     char resourcesDir[MAXPATHLEN];
     CFURLRef resourcesURL = CFBundleCopyResourcesDirectoryURL(CFBundleGetMainBundle());
     if (CFURLGetFileSystemRepresentation(resourcesURL, 1, (UInt8 *)resourcesDir, MAXPATHLEN)) {

--- a/src/gvl/support/platform.h
+++ b/src/gvl/support/platform.h
@@ -62,13 +62,17 @@
 #  define GVL_X86_64 1
 # elif defined(__i386__) || defined(_M_IX86) || defined(i386) || defined(i486) || defined(intel) || defined(x86) || defined(i86pc)
 #  define GVL_X86 1
+# elif defined(__arm__) || defined(_M_ARM)
+#  define GVL_ARM 1
+# elif defined(__aarch64__) || defined(_M_ARM64)
+#  define GVL_ARM_64 1
 # else
 #  error "Unknown architecture, please add it"
 # endif
 #endif
 
 #if !GVL_LITTLE_ENDIAN && !GVL_BIG_ENDIAN
-# if GVL_X86 || GVL_X86_64
+# if GVL_X86 || GVL_X86_64 || GVL_ARM || GVL_ARM_64
 #  define GVL_LITTLE_ENDIAN 1
 # else
 #  define GVL_BIG_ENDIAN 1
@@ -100,8 +104,8 @@
 #if !defined(GVL_X87)
 # if GVL_X86
 #  define GVL_X87 1 // Assume the compiler generates x87 code on x86 unless otherwise stated
-# elif GVL_X86_64
-#  define GVL_X87 0 // SSE2 is typically used on GVL_X86_64
+# elif GVL_X86_64 || GVL_ARM || GVL_ARM_64
+#  define GVL_X87 0
 # endif
 #endif
 

--- a/src/tl/platform.h
+++ b/src/tl/platform.h
@@ -62,7 +62,7 @@
 #  define TL_X86 1
 # elif defined(__arm__) || defined(_M_ARM)
 #  define TL_ARM 1
-# elif defined(__aarch_64__) || defined(_M_ARM64)
+# elif defined(__aarch64__) || defined(_M_ARM64)
 #  define TL_ARM_64 1
 # else
 #  error "Unknown architecture, please add it"
@@ -70,7 +70,7 @@
 #endif
 
 #if !TL_LITTLE_ENDIAN && !TL_BIG_ENDIAN
-# if TL_X86 || TL_X86_64 || TL_ARM || TL_ARM64
+# if TL_X86 || TL_X86_64 || TL_ARM || TL_ARM_64
 #  define TL_LITTLE_ENDIAN 1
 # else
 #  define TL_BIG_ENDIAN 1


### PR DESCRIPTION
This change adds support for Apple Silicon. It should now build without errors.

Tested on M5 Pro with macOS Tahoe 26.5.1

<img width="641" height="431" alt="image" src="https://github.com/user-attachments/assets/5871a51c-c8b4-4e9a-933f-0759e7666a4d" />
